### PR TITLE
Java buildpack compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: minimal
+script: ./tests/supply

--- a/README.md
+++ b/README.md
@@ -30,3 +30,18 @@ This buildpack does not attempt to resolve situations such as multiple results r
 To make configuration easier, YAML is the default configuration format. To parse this format, the buildpack downloads and uses [yq](https://github.com/mikefarah/yq). For users who cannot download external binaries or for users who prefer JSON for configuration, you can provide a mapping file in JSON format with a `.json` extension. This will skip downloading `yq` and so should work on security concious/air-gapped environments.
 
 To instruct the buildpack to use a JSON formatted file, use the `ENV_MAP_BP_CONFIG` environment variable detailed above.
+
+### Java Buildpack support
+
+The java buildpack ([cloudfoundry/java-buildpack](https://github.com/cloudfoundry/java-buildpack)) does not support
+sourcing environment variables from `deps/$IDX/profile.d` (which is part of the
+[core buildpack communication contract](https://docs.cloudfoundry.org/buildpacks/custom.html#-core-buildpack-communication-contract)).
+
+The env-map-buildpack relies on being able to use the `.profile.d` directory to set environment variables just before
+the application starts.
+
+To work around the java buildpack's lack of support for this, instead of writing to the `deps/$IDX/profile.d` directory
+env-map-buildpack can write directly to the app's `app/.profile.d` directory, which will get sourced, even in the java buildpack.
+
+To enable this behaviour, set the `ENV_MAP_BP_USE_APP_PROFILE_DIR` environment variable to `"true"`.
+

--- a/bin/supply
+++ b/bin/supply
@@ -20,23 +20,29 @@ else
   JSON_CONFIG="$(./yq r "$APP_DIR/$CONFIG" -j)"
 fi
 
-profile_dir="$DEPS_DIR/$IDX/profile.d"
-mkdir -p "$profile_dir"
-profile_file="$profile_dir/$IDX-mapped-env-vars.sh"
+function write_profile_d_script() {
+  local profile_dir=$1
 
-for var in $(echo "$JSON_CONFIG" | jq -r '.env_vars | keys[]'); do
-  selector="$(echo "$JSON_CONFIG" | jq -r ".env_vars.$var")"
-  echo "export $var=\"\$(echo \$VCAP_SERVICES | jq -r '$selector')\"" >> "$profile_file"
-done
+  mkdir -p "$profile_dir"
+  profile_file="$profile_dir/$IDX-mapped-env-vars.sh"
 
-# HACK:
-# The java buildpack doesn't support loading environment variables from .profile.d in deps/ID/profile.d
-# So we also have to copy it to app/.profile.d
-#
-# See https://github.com/cloudfoundry/java-buildpack/issues/563#issuecomment-452437417
-# and https://github.com/cyberark/cloudfoundry-conjur-buildpack/blob/31f4cbef/bin/supply#L96-L115
-mkdir -p "$APP_DIR/.profile.d/"
-cp "$profile_file" "$APP_DIR/.profile.d/"
+  for var in $(echo "$JSON_CONFIG" | jq -r '.env_vars | keys[]'); do
+    selector="$(echo "$JSON_CONFIG" | jq -r ".env_vars.$var")"
+    echo "export $var=\"\$(echo \$VCAP_SERVICES | jq -r '$selector')\"" >> "$profile_file"
+  done
+}
+
+if [[ "$ENV_MAP_BP_USE_APP_PROFILE_DIR" == "true" ]]; then
+  # HACK:
+  # The java buildpack doesn't support loading environment variables from .profile.d in deps/ID/profile.d
+  # So we also have to write it to app/.profile.d instead
+  #
+  # See https://github.com/cloudfoundry/java-buildpack/issues/563#issuecomment-452437417
+  # and https://github.com/cyberark/cloudfoundry-conjur-buildpack/blob/31f4cbef/bin/supply#L96-L115
+  write_profile_d_script "$APP_DIR/.profile.d/"
+else
+  write_profile_d_script "$DEPS_DIR/$IDX/profile.d"
+fi
 
 echo "$log_prefix Done."
 exit 0

--- a/bin/supply
+++ b/bin/supply
@@ -20,11 +20,23 @@ else
   JSON_CONFIG="$(./yq r "$APP_DIR/$CONFIG" -j)"
 fi
 
-mkdir -p "$DEPS_DIR/$IDX/profile.d"
+profile_dir="$DEPS_DIR/$IDX/profile.d"
+mkdir -p "$profile_dir"
+profile_file="$profile_dir/$IDX-mapped-env-vars.sh"
+
 for var in $(echo "$JSON_CONFIG" | jq -r '.env_vars | keys[]'); do
   selector="$(echo "$JSON_CONFIG" | jq -r ".env_vars.$var")"
-  echo "export $var=\"\$(echo \$VCAP_SERVICES | jq -r '$selector')\"" >> "$DEPS_DIR/$IDX/profile.d/$IDX-mapped-env-vars.sh"
+  echo "export $var=\"\$(echo \$VCAP_SERVICES | jq -r '$selector')\"" >> "$profile_file"
 done
+
+# HACK:
+# The java buildpack doesn't support loading environment variables from .profile.d in deps/ID/profile.d
+# So we also have to copy it to app/.profile.d
+#
+# See https://github.com/cloudfoundry/java-buildpack/issues/563#issuecomment-452437417
+# and https://github.com/cyberark/cloudfoundry-conjur-buildpack/blob/31f4cbef/bin/supply#L96-L115
+mkdir -p "$APP_DIR/.profile.d/"
+cp "$profile_file" "$APP_DIR/.profile.d/"
 
 echo "$log_prefix Done."
 exit 0

--- a/bin/supply
+++ b/bin/supply
@@ -15,7 +15,7 @@ if [[ $CONFIG =~ .json ]]; then
   JSON_CONFIG="$(< "$APP_DIR/$CONFIG")"
 else
   echo "$log_prefix Downloading yq"
-  curl -L https://github.com/mikefarah/yq/releases/download/2.4.1/yq_linux_amd64 -o yq
+  curl --silent --location https://github.com/mikefarah/yq/releases/download/2.4.1/yq_linux_amd64 -o yq
   chmod +x yq
   JSON_CONFIG="$(./yq r "$APP_DIR/$CONFIG" -j)"
 fi

--- a/bin/supply
+++ b/bin/supply
@@ -1,30 +1,31 @@
 #!/bin/bash
-# bin/compile <build-dir> <cache-dir>
 
-set -ex
+set -e
 
 APP_DIR=$1
-CACHE_DIR=$2
 DEPS_DIR=$3
 IDX=$4
 
-CONFIG=${ENV_MAP_BP_CONFIG:-"env-map.yml"}
-echo "Creating profile.d file using $CONFIG"
+log_prefix='-----> [env-map-buildpack]'
 
-if [[ $CONFIG =~ ".json" ]]; then
-  JSON_CONFIG="$(cat $APP_DIR/$CONFIG)"
+CONFIG=${ENV_MAP_BP_CONFIG:-"env-map.yml"}
+echo "$log_prefix Creating profile.d file using $CONFIG"
+
+if [[ $CONFIG =~ .json ]]; then
+  JSON_CONFIG="$(< "$APP_DIR/$CONFIG")"
 else
-  echo "Downloading yq"
+  echo "$log_prefix Downloading yq"
   curl -L https://github.com/mikefarah/yq/releases/download/2.4.1/yq_linux_amd64 -o yq
   chmod +x yq
-  JSON_CONFIG="$(./yq r $APP_DIR/$CONFIG -j)"
+  JSON_CONFIG="$(./yq r "$APP_DIR/$CONFIG" -j)"
 fi
 
-mkdir -p $DEPS_DIR/$IDX/profile.d
+mkdir -p "$DEPS_DIR/$IDX/profile.d"
 for var in $(echo "$JSON_CONFIG" | jq -r '.env_vars | keys[]'); do
-	selector="$(echo "$JSON_CONFIG" | jq -r ".env_vars.$var")"
-  echo "export $var=\"\$(echo \$VCAP_SERVICES | jq -r '$selector')\"" >> $DEPS_DIR/$IDX/profile.d/$IDX-mapped-env-vars.sh
+  selector="$(echo "$JSON_CONFIG" | jq -r ".env_vars.$var")"
+  echo "export $var=\"\$(echo \$VCAP_SERVICES | jq -r '$selector')\"" >> "$DEPS_DIR/$IDX/profile.d/$IDX-mapped-env-vars.sh"
 done
 
-echo "-----> Done."
+echo "$log_prefix Done."
 exit 0
+

--- a/tests/supply
+++ b/tests/supply
@@ -19,25 +19,30 @@ function test_creates_profile_d {
   echo '{"env_vars":{"KEY": "VALUE"}}' > app/env-map.json
   export ENV_MAP_BP_CONFIG="env-map.json"
 
-  "$supply" ./app IGNORED ./deps 0 &> /dev/null
+  "$supply" ./app IGNORED ./deps 0 #&> /dev/null
 
-  local file_path=./deps/0/profile.d/0-mapped-env-vars.sh
-  if [[ ! -f "$file_path" ]]; then
-    >&2 echo "FAIL: expected to find a mapping script in profile.d"
-    >&2 echo "Files were:"
-    >&2 tree
-    exit 1
-  fi
+  local file_paths=(
+    ./deps/0/profile.d/0-mapped-env-vars.sh
+    ./app/.profile.d/0-mapped-env-vars.sh
+  )
+  for file_path in "${file_paths[@]}"; do
+    if [[ ! -f "$file_path" ]]; then
+      >&2 echo "FAIL: expected to find a mapping script in profile.d"
+      >&2 echo "Files were:"
+      >&2 tree
+      exit 1
+    fi
 
-  # shellcheck disable=SC2016
-  expected='export KEY="$(echo $VCAP_SERVICES | jq -r '"'VALUE'"')"'
+    # shellcheck disable=SC2016
+    expected='export KEY="$(echo $VCAP_SERVICES | jq -r '"'VALUE'"')"'
 
-  if ! grep -q -F "$expected" "$file_path"; then
-    >&2 echo "FAIL: expected to find an export of '$expected'"
-    >&2 echo "Instead, found:"
-    >&2 cat "$file_path"
-    exit 1
-  fi
+    if ! grep -q -F "$expected" "$file_path"; then
+      >&2 echo "FAIL: expected to find an export of '$expected'"
+      >&2 echo "Instead, found:"
+      >&2 cat "$file_path"
+      exit 1
+    fi
+  done
 
   echo "PASS"
 }

--- a/tests/supply
+++ b/tests/supply
@@ -11,8 +11,8 @@ function use_tmp_environment {
   mkdir -p deps/0
 }
 
-function test_creates_profile_d {
-  echo "TEST: should create profile.d and add a script exporting variables"
+function test_creates_profile_d_in_deps_dir {
+  echo "TEST: should create deps/0/profile.d and add a script exporting variables"
 
   use_tmp_environment 'env-map-buildpack-test-creates-profile-d'
 
@@ -21,31 +21,69 @@ function test_creates_profile_d {
 
   "$supply" ./app IGNORED ./deps 0 #&> /dev/null
 
-  local file_paths=(
-    ./deps/0/profile.d/0-mapped-env-vars.sh
-    ./app/.profile.d/0-mapped-env-vars.sh
-  )
-  for file_path in "${file_paths[@]}"; do
-    if [[ ! -f "$file_path" ]]; then
-      >&2 echo "FAIL: expected to find a mapping script in profile.d"
-      >&2 echo "Files were:"
-      >&2 tree
-      exit 1
-    fi
+  local file_path=./deps/0/profile.d/0-mapped-env-vars.sh
+  if [[ ! -f "$file_path" ]]; then
+    >&2 echo "FAIL: expected to find a mapping script in profile.d"
+    >&2 echo "Files were:"
+    >&2 tree
+    exit 1
+  fi
 
-    # shellcheck disable=SC2016
-    expected='export KEY="$(echo $VCAP_SERVICES | jq -r '"'VALUE'"')"'
+  # shellcheck disable=SC2016
+  expected='export KEY="$(echo $VCAP_SERVICES | jq -r '"'VALUE'"')"'
 
-    if ! grep -q -F "$expected" "$file_path"; then
-      >&2 echo "FAIL: expected to find an export of '$expected'"
-      >&2 echo "Instead, found:"
-      >&2 cat "$file_path"
-      exit 1
-    fi
-  done
+  if ! grep -q -F "$expected" "$file_path"; then
+    >&2 echo "FAIL: expected to find an export of '$expected'"
+    >&2 echo "Instead, found:"
+    >&2 cat "$file_path"
+    exit 1
+  fi
+
+  if [[ -f "./app/.profile.d/0-mapped-env-vars.sh" ]]; then
+    >&2 echo "FAIL: expected not to find a mapping file in the app's profile.d dir"
+    exit 1
+  fi
 
   echo "PASS"
 }
 
-test_creates_profile_d
+function test_creates_profile_d_in_app_dir {
+  echo "TEST: should create app/.profile.d and add a script exporting variables"
+
+  use_tmp_environment 'env-map-buildpack-test-creates-profile-d'
+
+  echo '{"env_vars":{"KEY": "VALUE"}}' > app/env-map.json
+  export ENV_MAP_BP_CONFIG="env-map.json"
+  export ENV_MAP_BP_USE_APP_PROFILE_DIR="true"
+
+  "$supply" ./app IGNORED ./deps 0 #&> /dev/null
+
+  local file_path=./app/.profile.d/0-mapped-env-vars.sh
+  if [[ ! -f "$file_path" ]]; then
+    >&2 echo "FAIL: expected to find a mapping script in profile.d"
+    >&2 echo "Files were:"
+    >&2 tree
+    exit 1
+  fi
+
+  # shellcheck disable=SC2016
+  expected='export KEY="$(echo $VCAP_SERVICES | jq -r '"'VALUE'"')"'
+
+  if ! grep -q -F "$expected" "$file_path"; then
+    >&2 echo "FAIL: expected to find an export of '$expected'"
+    >&2 echo "Instead, found:"
+    >&2 cat "$file_path"
+    exit 1
+  fi
+
+  if [[ -f "./deps/0/profile.d/0-mapped-env-vars.sh" ]]; then
+    >&2 echo "FAIL: expected not to find a mapping file in the deps/0/profile.d dir"
+    exit 1
+  fi
+
+  echo "PASS"
+}
+
+test_creates_profile_d_in_deps_dir
+test_creates_profile_d_in_app_dir
 

--- a/tests/supply
+++ b/tests/supply
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+supply=$(cd "$(dirname "$0")/../bin" && pwd)/supply
+
+function use_tmp_environment {
+  local name=$1
+  cd "$(mktemp -d -t "$name.XXXXX")"
+  mkdir app
+  mkdir -p deps/0
+}
+
+function test_creates_profile_d {
+  echo "TEST: should create profile.d and add a script exporting variables"
+
+  use_tmp_environment 'env-map-buildpack-test-creates-profile-d'
+
+  echo '{"env_vars":{"KEY": "VALUE"}}' > app/env-map.json
+  export ENV_MAP_BP_CONFIG="env-map.json"
+
+  "$supply" ./app IGNORED ./deps 0 &> /dev/null
+
+  local file_path=./deps/0/profile.d/0-mapped-env-vars.sh
+  if [[ ! -f "$file_path" ]]; then
+    >&2 echo "FAIL: expected to find a mapping script in profile.d"
+    >&2 echo "Files were:"
+    >&2 tree
+    exit 1
+  fi
+
+  # shellcheck disable=SC2016
+  expected='export KEY="$(echo $VCAP_SERVICES | jq -r '"'VALUE'"')"'
+
+  if ! grep -q -F "$expected" "$file_path"; then
+    >&2 echo "FAIL: expected to find an export of '$expected'"
+    >&2 echo "Instead, found:"
+    >&2 cat "$file_path"
+    exit 1
+  fi
+
+  echo "PASS"
+}
+
+test_creates_profile_d
+


### PR DESCRIPTION
What
----

Added an environment variable `ENV_MAP_BP_USE_APP_PROFILE_DIR` which will cause the env-map-buildpack to write it's script directly to the app's directory instead of the "proper" location (which would be `deps/$IDX/profile.d`).

This is needed to workaround a problem with the java buildpack, wherein it doesn't source profile directories from other buildpacks in a multi-buildpack setup.

See the README and the comments for more detail.

Also adds some bash unit tests and enables travis.

How to review
-------------

* Code review
* Try pushing a java app using this version of the buildpack, and confirm that it can set env vars (you can use https://github.com/richardtowers/env-map-buildpack#java-buildpack-compat-pr as a custom buildpack to get this branch)

Who can review
--------------

Not @richardTowers. This probably needs someone from the paas team to review, since I think it makes more sense for them to "own" this code, but I'll get my colleagues on the pay team to have a look.
